### PR TITLE
Initialize Go module with CI tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,19 @@
+name: Go
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.x"
+      - run: go test ./...
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # sync-leaf
+
+This repository contains a minimal Go module with a sample `Hello` function and accompanying tests. Continuous Integration is configured via GitHub Actions to run `go test ./...` on pushes to `main` and on pull requests.
+

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module sync-leaf
+
+go 1.24.3

--- a/greetings/greetings.go
+++ b/greetings/greetings.go
@@ -1,0 +1,5 @@
+package greetings
+
+func Hello() string {
+	return "Hello, world!"
+}

--- a/greetings/greetings_test.go
+++ b/greetings/greetings_test.go
@@ -1,0 +1,10 @@
+package greetings
+
+import "testing"
+
+func TestHello(t *testing.T) {
+	want := "Hello, world!"
+	if got := Hello(); got != want {
+		t.Fatalf("Hello() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- set up Go module with basic Hello world package and tests
- add GitHub Actions workflow to run `go test ./...` on pushes to `main` and pull requests
- document Go module and CI in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689fc17d3a5083308e3ca99fc675b2dd