### PR TITLE
chore: add repo guidelines and automation

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,8 +12,31 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
           go-version: "1.24.x"
+      - name: Go fmt
+        run: |
+          git fetch origin main
+          files=$(git diff --name-only --diff-filter=ACM origin/main | grep '\.go$' || true)
+          if [ -z "$files" ]; then
+            echo "No Go files changed"
+            exit 0
+          fi
+          unformatted=$(gofmt -l $files)
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not formatted:"
+            echo "$unformatted"
+            exit 1
+          fi
+      - name: Go lint
+        run: |
+          git fetch origin main
+          files=$(git diff --name-only --diff-filter=ACM origin/main | grep '\.go$' || true)
+          if [ -n "$files" ]; then
+            go install golang.org/x/lint/golint@latest
+            golint -set_exit_status $files
+          fi
       - run: go test ./...
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Repository Guidelines
+
+- This project is AI-friendly; contributions from AI assistants are welcome.
+- Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for all commit messages.
+- Follow test-driven development (TDD): write tests before implementing features.
+- Run `go fmt` and `golint` on all Go code and ensure `go test ./...` passes before committing.
+

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"]
+}


### PR DESCRIPTION
## Summary
- document contribution rules for AI, conventional commits, and TDD
- run gofmt and golint in CI only on changed files
- configure Renovate for dependency updates

## Testing
- `gofmt -w -l $(git ls-files '*.go')`
- `go install golang.org/x/lint/golint@latest` *(fails: Forbidden)*
- `golint ./...` *(fails: command not found)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689fc2d5e8dc8330b835eaba5c2c8651