### PR TITLE
docs: track initial tasks for WebRTC sync app

### DIFF
--- a/tasks.md
+++ b/tasks.md
@@ -1,0 +1,16 @@
+# Task List
+
+This file tracks the high-level tasks required to build the sync application.
+
+## Initial Plan
+- [ ] Define the overall project architecture for a folder synchronization app using WebRTC.
+- [ ] Implement a basic, cross-platform file watcher with a pluggable interface for future enhancements.
+- [ ] Establish a WebRTC data channel to sync files between peers.
+- [ ] Add basic authentication for connecting peers.
+- [ ] Provide a configuration mechanism to specify folders to sync.
+- [ ] Integrate `go vet` and `staticcheck` into the CI pipeline.
+- [ ] Set up test coverage reporting and add a coverage badge to the README.
+- [ ] Document setup, usage, and development workflows.
+
+> Tests should accompany each step and be written alongside features.
+


### PR DESCRIPTION
## Summary
- add `tasks.md` with initial plan for WebRTC folder synchronization app
- outline tasks for watcher, authentication, and synchronization
- expand task list for cross-platform watcher, CI checks, and coverage badge

## Testing
- `go fmt ./...`
- `golint ./...` *(fails: command not found)*
- `go test -v ./...`


------
https://chatgpt.com/codex/tasks/task_b_689fc7fb704083308c58684e42668eca