### PR TITLE
ci: add coverage reporting and badge

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,4 +39,9 @@ jobs:
             go install golang.org/x/lint/golint@latest
             golint -set_exit_status $files
           fi
-      - run: go test ./...
+      - name: Run tests with coverage
+        run: go test ./... -coverprofile=coverage.out
+      - name: Upload coverage
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.out

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # sync-leaf
 
+[![Coverage](https://codecov.io/gh/sync-leaf/sync-leaf/branch/main/graph/badge.svg)](https://codecov.io/gh/sync-leaf/sync-leaf)
+
 This repository contains a minimal Go module with a sample `Hello` function and accompanying tests. Continuous Integration is configured via GitHub Actions to run `go test ./...` on pushes to `main` and on pull requests.
 


### PR DESCRIPTION
## Summary
- upload Go coverage reports to Codecov via GitHub Actions
- show Codecov coverage badge in README

## Testing
- `go test ./... -coverprofile=coverage.out` *(fails: golint command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689fcd8478e08330890c5dfaff1f7617