### PR TITLE
ci: add go vet and staticcheck to workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,4 +39,10 @@ jobs:
             go install golang.org/x/lint/golint@latest
             golint -set_exit_status $files
           fi
+      - name: Go vet
+        run: go vet ./...
+      - name: Staticcheck
+        run: |
+          go install honnef.co/go/tools/cmd/staticcheck@latest
+          staticcheck ./...
       - run: go test ./...


### PR DESCRIPTION
## Summary
- run go vet during CI
- run staticcheck during CI

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`
- `go install golang.org/x/lint/golint@latest` (fails: module golang.org/x/lint/golint: Get "https://proxy.golang.org/golang.org/x/lint/golint/@v/list": Forbidden)
- `golint ./...` (fails: command not found)
- `go install honnef.co/go/tools/cmd/staticcheck@latest` (fails: module honnef.co/go/tools/cmd/staticcheck: Get "https://proxy.golang.org/honnef.co/go/tools/cmd/staticcheck/@v/list": Forbidden)
- `staticcheck ./...` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_b_689fcd7cfdfc8330b27f15557c59d6a1