### PR TITLE
fix: correct Go workflow formatting

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,7 +38,8 @@ jobs:
           if [ -n "$files" ]; then
             go install golang.org/x/lint/golint@latest
             golint -set_exit_status $files
-          fi      - name: Go vet
+          fi
+      - name: Go vet
         run: go vet ./...
       - name: Staticcheck
         run: |


### PR DESCRIPTION
## Summary
- fix go.yml formatting so Go vet runs as separate step

## Testing
- `go fmt ./...`
- `go test ./...`
- Attempted to `go install golang.org/x/lint/golint@latest` (fails: module proxy 403)

------
https://chatgpt.com/codex/tasks/task_b_689fcf049a288330bd9ef6c5f61775de