### PR TITLE
feat(watcher): add watcher interface and event types

### DIFF
--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -1,0 +1,43 @@
+package watcher
+
+import (
+	"errors"
+	"io/fs"
+)
+
+// Op describes the type of file system operation.
+type Op uint32
+
+const (
+	// Create indicates a new file or directory was created.
+	Create Op = 1 << iota
+	// Write indicates a file or directory was written to.
+	Write
+	// Rename indicates a file or directory was renamed.
+	Rename
+	// Remove indicates a file or directory was removed.
+	Remove
+)
+
+// Event represents a file system event.
+type Event struct {
+	Path string      // Path to the file or directory.
+	Op   Op          // Operation that triggered the event.
+	Info fs.FileInfo // File metadata at the time of the event.
+}
+
+// Watcher defines the behavior of a file system watcher.
+type Watcher interface {
+	// Start begins watching for file system changes.
+	Start() error
+	// Close stops watching and releases any associated resources.
+	Close() error
+	// Events returns a channel that receives file system events.
+	Events() <-chan Event
+	// Errors returns a channel that receives watcher errors.
+	Errors() <-chan error
+}
+
+// ErrUnsupported is returned when a watcher operation is not supported on the
+// current platform.
+var ErrUnsupported = errors.New("watcher: unsupported platform or operation")

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -1,0 +1,25 @@
+package watcher
+
+import "testing"
+
+func TestErrUnsupported(t *testing.T) {
+	if ErrUnsupported == nil {
+		t.Fatalf("ErrUnsupported is nil")
+	}
+}
+
+func TestOpValues(t *testing.T) {
+	ops := []Op{Create, Write, Rename, Remove}
+	for _, op := range ops {
+		if op == 0 {
+			t.Fatalf("op %v is zero", op)
+		}
+	}
+}
+
+func TestEvent(t *testing.T) {
+	e := Event{Path: "file.txt", Op: Create}
+	if e.Path != "file.txt" {
+		t.Fatalf("Event.Path = %q, want %q", e.Path, "file.txt")
+	}
+}


### PR DESCRIPTION
## Summary
- add Watcher interface with lifecycle and channel methods
- define Event struct and Op constants for filesystem notifications
- expose ErrUnsupported for unsupported platforms or operations

## Testing
- `go fmt pkg/watcher/watcher.go pkg/watcher/watcher_test.go`
- `golint pkg/watcher/...` *(fails: command not found)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689fe2b14ce48330b732928996d5e4d7